### PR TITLE
update go version

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "github.com/IBM-Cloud/get-started-go",
-	"GoVersion": "go1.11",
+	"GoVersion": "go1.12",
 	"GodepVersion": "v79",
 	"Deps": [
 		{


### PR DESCRIPTION
CF version on staging has been updated. 
The previous go buildpack version was v1.8.42.   After the CF update the go buildpack version is
1.9.3.   The getting started app specifies v1.11 which is no longer in the buildpack.   v1.12.x is common in both.  